### PR TITLE
Update build-c-shared-library.elv

### DIFF
--- a/script/build-c-shared-library.elv
+++ b/script/build-c-shared-library.elv
@@ -1,6 +1,6 @@
 #elvish script
 fn scriptWD {
-    wd=(path-dir (src)[path])
+    wd=(path-dir (src)[name])
     echo cd $wd
     cd $wd
 }


### PR DESCRIPTION
The "path" field of (src) has been removed. Use "name" to get the path of file sources.